### PR TITLE
Fix/validacoes cadastrar certificado

### DIFF
--- a/src/app/registrar-certificado/[requestID]/page.tsx
+++ b/src/app/registrar-certificado/[requestID]/page.tsx
@@ -51,7 +51,7 @@ export default function RegistePageTest({ params }: idProps) {
     setErrorSelectedAtividade(selectedAtividade === '0');
     setErrorTitulo(titulo === '');
     setErrorDataInicial(dataInicial === '');
-    setErrorDataFinal(dataFinal === '');
+    setErrorDataFinal(dataFinal === '' || dataInicial > dataFinal);
     setErrorHoras(parseInt(horas) < 1 || horas === '');
   };
 
@@ -188,6 +188,7 @@ export default function RegistePageTest({ params }: idProps) {
     setErrorTitulo(titulo === '');
     setErrorDataInicial(dataInicial === '');
     setErrorDataFinal(dataFinal === '');
+    setErrorDataFinal(dataInicial > dataFinal);
     setErrorHoras(parseInt(horas) < 1 || horas === '');
 
     const isValidInputs =
@@ -199,6 +200,10 @@ export default function RegistePageTest({ params }: idProps) {
 
     if (isValidInputs) {
       registerCertificate();
+    }
+
+    if (errorDataFinal) {
+      errorToast('Selecione uma data final posterior a data inicial.');
     }
   };
 
@@ -301,7 +306,7 @@ export default function RegistePageTest({ params }: idProps) {
                 min={minDate}
               />
               {errorDataFinal ? (
-                <S.ErrorSpan>*Selecione uma data</S.ErrorSpan>
+                <S.ErrorSpan>*Selecione uma data válida</S.ErrorSpan>
               ) : (
                 <></>
               )}

--- a/src/app/registrar-certificado/[requestID]/page.tsx
+++ b/src/app/registrar-certificado/[requestID]/page.tsx
@@ -52,7 +52,9 @@ export default function RegistePageTest({ params }: idProps) {
     setErrorTitulo(titulo === '');
     setErrorDataInicial(dataInicial === '');
     setErrorDataFinal(dataFinal === '' || dataInicial > dataFinal);
-    setErrorHoras(parseInt(horas) < 1 || horas === '');
+    setErrorHoras(
+      parseInt(horas) < 1 || horas === '' || parseInt(horas) > 5000
+    );
   };
 
   const request = useCallback(async () => {
@@ -189,7 +191,9 @@ export default function RegistePageTest({ params }: idProps) {
     setErrorDataInicial(dataInicial === '');
     setErrorDataFinal(dataFinal === '');
     setErrorDataFinal(dataInicial > dataFinal);
-    setErrorHoras(parseInt(horas) < 1 || horas === '');
+    setErrorHoras(
+      parseInt(horas) < 1 || horas === '' || parseInt(horas) > 5000
+    );
 
     const isValidInputs =
       !errorSelectedAtividade &&
@@ -322,6 +326,7 @@ export default function RegistePageTest({ params }: idProps) {
                 onChange={handleChangeHoras}
                 value={horas}
                 disabled={isReadyToSent}
+                max={5000}
               />
               {errorHoras ? (
                 <S.ErrorSpan>*Entrada inválida</S.ErrorSpan>


### PR DESCRIPTION
Corrigindo as validações de horas (colocando limite de 5000 horas) e corrigindo a validação da data que não funcionava quando o usuário digitava manualmente 